### PR TITLE
Use shared managers and add team support

### DIFF
--- a/EquipmentManager.swift
+++ b/EquipmentManager.swift
@@ -2,7 +2,7 @@
 import Foundation
 import SwiftData
 
-final class EquipmentManager {
+final class EquipmentManager: ObservableObject {
     static let shared = EquipmentManager()
     private init() {}
 

--- a/GuildManager.swift
+++ b/GuildManager.swift
@@ -2,7 +2,7 @@
 import Foundation
 import SwiftData
 
-final class GuildManager {
+final class GuildManager: ObservableObject {
     static let shared = GuildManager()
     private init() {}
 

--- a/Managers.swift
+++ b/Managers.swift
@@ -109,37 +109,6 @@ final class SpellbookManager {
 }
 
 
-// MARK: - Quest Manager
-
-final class QuestManager {
-    static let shared = QuestManager()
-    private init() {}
-    func initializeQuests(for user: User, context: ModelContext) {
-        guard user.quests?.isEmpty ?? true else { return }
-        for template in ItemDatabase.shared.masterQuestList {
-            let newQuest = Quest(id: template.id, title: template.title, description: template.questDescription, type: template.type, rewards: template.rewards, owner: user)
-            context.insert(newQuest)
-            user.quests?.append(newQuest)
-        }
-    }
-    func updateQuestProgress(forCompletedTask task: TaskItem, on user: User) {
-        guard let activeQuests = user.quests?.filter({ $0.status == .active }) else { return }
-        for quest in activeQuests {
-            switch quest.type {
-            case .milestone(let c, let n): if c == task.category { quest.progress += 1 }; if quest.progress >= n { quest.status = .completed }
-            case .streak(let c, let d): if c == task.category { quest.progress += 1 }; if quest.progress >= d { quest.status = .completed }
-            case .exploration(let c): if c.contains(task.category) { quest.progress += 1 }; if quest.progress >= c.count { quest.status = .completed }
-            }
-        }
-    }
-    func claimQuestReward(for quest: Quest, on user: User, context: ModelContext) {
-        for reward in quest.rewards { IdleGameManager.shared.grantLoot(reward, to: user, context: context) }
-        context.delete(quest)
-    }
-    
-}
-
-
 // MARK: - Obsidian Gymnasium Manager
 
 final class ObsidianGymnasiumManager {

--- a/Models.swift
+++ b/Models.swift
@@ -178,7 +178,9 @@ final class User {
     }
 
     @Relationship(deleteRule: .cascade, inverse: \Guild.owner) var guild: Guild?
+    @Relationship(inverse: \Team.members) var team: Team?
     var guildSeals: Int = 0
+    var teamPoints: Int = 0
 
 
     init(username: String) {
@@ -193,7 +195,9 @@ final class User {
         self.runes = 5; self.isDoubleXpNextTask = false; self.unlockedSpellIDs = []; self.activeBuffs = [:]
         self.altarOfWhispers = nil
         self.guild = nil
+        self.team = nil
         self.guildSeals = 0
+        self.teamPoints = 0
     }
 
     /// Some legacy code still expects a `name` property on `User`.
@@ -226,6 +230,19 @@ final class Guild {
 
     var xpToNextLevel: Int {
         return level * 1000 // Simple scaling for now
+    }
+}
+
+@Model
+final class Team {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    @Relationship(deleteRule: .cascade, inverse: \User.team) var members: [User]?
+
+    init(name: String, owner: User) {
+        self.id = UUID()
+        self.name = name
+        self.members = [owner]
     }
 }
 

--- a/ProjectChimeraApp.swift
+++ b/ProjectChimeraApp.swift
@@ -2,16 +2,16 @@ import SwiftUI
 
 @main
 struct ProjectChimeraApp: App {
-    // CORRECTED: Create a separate @StateObject for each manager.
-    // This ensures each manager's lifecycle is correctly managed by SwiftUI
-    // and resolves the access level issues by initializing them here.
-    @StateObject private var gameManager = IdleGameManager()
+    // Each manager is initialized using its shared singleton instance. This
+    // avoids access level issues from private initializers while still allowing
+    // SwiftUI to manage their lifecycle via `@StateObject`.
+    @StateObject private var gameManager = IdleGameManager.shared
     @StateObject private var healthKitManager = HealthKitManager()
-    @StateObject private var onboardingManager = OnboardingManager()
-    @StateObject private var equipmentManager = EquipmentManager()
-    @StateObject private var sanctuaryManager = SanctuaryManager()
-    @StateObject private var guildManager = GuildManager()
-    @StateObject private var shopManager = ShopManager()
+    @StateObject private var onboardingManager = OnboardingManager.shared
+    @StateObject private var equipmentManager = EquipmentManager.shared
+    @StateObject private var sanctuaryManager = SanctuaryManager.shared
+    @StateObject private var guildManager = GuildManager.shared
+    @StateObject private var shopManager = ShopManager.shared
 
     var body: some Scene {
         WindowGroup {

--- a/QuestManager.swift
+++ b/QuestManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftData
+
+/// Handles creation and progression of quests for a user.
+final class QuestManager {
+    static let shared = QuestManager()
+    private init() {}
+
+    func initializeQuests(for user: User, context: ModelContext) {
+        guard user.quests?.isEmpty ?? true else { return }
+        for template in ItemDatabase.shared.masterQuestList {
+            let newQuest = Quest(
+                id: template.id,
+                title: template.title,
+                description: template.questDescription,
+                type: template.type,
+                rewards: template.rewards,
+                owner: user
+            )
+            context.insert(newQuest)
+            user.quests?.append(newQuest)
+        }
+    }
+
+    func updateQuestProgress(forCompletedTask task: TaskItem, on user: User) {
+        guard let activeQuests = user.quests?.filter({ $0.status == .active }) else { return }
+        for quest in activeQuests {
+            switch quest.type {
+            case .milestone(let category, let count):
+                if category == task.category {
+                    quest.progress += 1
+                    if quest.progress >= count { quest.status = .completed }
+                }
+            case .streak(let category, let days):
+                if category == task.category {
+                    quest.progress += 1
+                    if quest.progress >= days { quest.status = .completed }
+                }
+            case .exploration(let categories):
+                if categories.contains(task.category) {
+                    quest.progress += 1
+                    if quest.progress >= categories.count { quest.status = .completed }
+                }
+            }
+        }
+    }
+
+    func claimQuestReward(for quest: Quest, on user: User, context: ModelContext) {
+        for reward in quest.rewards {
+            IdleGameManager.shared.grantLoot(reward, to: user, context: context)
+        }
+        context.delete(quest)
+    }
+}

--- a/SanctuaryManager.swift
+++ b/SanctuaryManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftData
 
-final class SanctuaryManager {
+final class SanctuaryManager: ObservableObject {
     static let shared = SanctuaryManager()
     private init() {}
 

--- a/ShopManager.swift
+++ b/ShopManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftData
 
-final class ShopManager {
+final class ShopManager: ObservableObject {
     static let shared = ShopManager()
     private init() {}
 

--- a/TeamManager.swift
+++ b/TeamManager.swift
@@ -1,0 +1,19 @@
+import Foundation
+import SwiftData
+
+/// Provides basic team management such as creation and point tracking.
+final class TeamManager: ObservableObject {
+    static let shared = TeamManager()
+    private init() {}
+
+    func createTeam(name: String, for user: User, context: ModelContext) {
+        guard user.team == nil else { return }
+        let team = Team(name: name, owner: user)
+        context.insert(team)
+        user.team = team
+    }
+
+    func addPoints(_ points: Int, to user: User) {
+        user.teamPoints += points
+    }
+}


### PR DESCRIPTION
## Summary
- Initialize managers via their shared singleton instances and conform manager classes to `ObservableObject`
- Move QuestManager into its own file to avoid redeclaration conflicts
- Introduce basic Team model and TeamManager with `team` relationship on `User`

## Testing
- `swiftc -typecheck *.swift` *(fails: no such module 'SwiftData')*


------
https://chatgpt.com/codex/tasks/task_e_6894e9e5e79c832facdd6bafa2aa2d53