### PR TITLE
Fix SwiftData relationship cycle and predicate

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -9,8 +9,8 @@ struct ContentView: View {
     @EnvironmentObject var onboardingManager: OnboardingManager
 
     @Query(filter: #Predicate<UserTask> { task in
-        task.difficulty == TaskDifficulty.easy &&
-            task.associatedStat == ChimeraStat.intellect
+        task.difficulty == .easy &&
+            task.associatedStat == .intellect
     }) var tasks: [UserTask]
 
     var body: some View {

--- a/Models.swift
+++ b/Models.swift
@@ -178,7 +178,7 @@ final class User {
     }
 
     @Relationship(deleteRule: .cascade, inverse: \Guild.owner) var guild: Guild?
-    @Relationship(inverse: \Team.members) var team: Team?
+    var team: Team?
     var guildSeals: Int = 0
     var teamPoints: Int = 0
 
@@ -237,7 +237,7 @@ final class Guild {
 final class Team {
     @Attribute(.unique) var id: UUID
     var name: String
-    @Relationship(deleteRule: .cascade, inverse: \User.team) var members: [User]?
+    @Relationship(deleteRule: .cascade) var members: [User]?
 
     init(name: String, owner: User) {
         self.id = UUID()


### PR DESCRIPTION
## Summary
- avoid enum key path usage in `ContentView` query predicate
- simplify `User`/`Team` SwiftData relationship to prevent macro errors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894fe0aa6f0832f9e2e56ff46426e44