### PR TITLE
Implement guild mercenary quest system

### DIFF
--- a/GuildMasterView.swift
+++ b/GuildMasterView.swift
@@ -9,6 +9,8 @@ struct GuildMasterView: View {
     private var guild: Guild? { user.guild }
     private var activeBounties: [GuildBounty] { (user.guildBounties ?? []).filter { $0.isActive } }
 
+    @State private var timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -25,6 +27,16 @@ struct GuildMasterView: View {
                     GuildProgressionView(guild: guild)
                 }
 
+                Section(header: Text("Hire Mercenaries").font(.title2).bold()) {
+                    HireMercenariesRow(user: user, modelContext: modelContext)
+                }
+                .padding(.horizontal)
+
+                Section(header: Text("Active Hunts").font(.title2).bold()) {
+                    HuntsSection(user: user, modelContext: modelContext)
+                }
+                .padding(.horizontal)
+
                 Section(header: Text("Guild Bounties").font(.title2).bold()) {
                     if activeBounties.isEmpty {
                         Text("No active bounties today. Check back tomorrow!")
@@ -40,6 +52,9 @@ struct GuildMasterView: View {
             .padding(.vertical)
         }
         .navigationTitle("Guild Master")
+        .onReceive(timer) { _ in
+            GuildManager.shared.processHunts(for: user, deltaTime: 1.0, context: modelContext)
+        }
     }
 }
 
@@ -103,6 +118,111 @@ struct GuildBountyCardView: View {
         }
         .padding()
         .background(Material.regular)
+        .cornerRadius(10)
+    }
+}
+
+struct HireMercenariesRow: View {
+    @Bindable var user: User
+    var modelContext: ModelContext
+
+    private let combatRoles: [GuildMember.Role] = [.knight, .archer, .wizard, .rogue, .cleric]
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                ForEach(combatRoles, id: \.self) { role in
+                    Button("Hire \(role.rawValue)") {
+                        GuildManager.shared.hireGuildMember(role: role, for: user, context: modelContext)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .font(.caption)
+            .foregroundColor(.secondary)
+            Text("250 gold each. Combatants will fight in your hunts.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Material.regular)
+        .cornerRadius(10)
+    }
+}
+
+struct HuntsSection: View {
+    @Bindable var user: User
+    var modelContext: ModelContext
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Start a goblin hunt quick action
+            Button {
+                let combatantIDs = (user.guildMembers ?? []).filter { $0.isCombatant }.map { $0.id }
+                guard !combatantIDs.isEmpty else { return }
+                GuildManager.shared.startHunt(enemyID: "enemy_goblin", with: combatantIDs, for: user, context: modelContext)
+            } label: {
+                Label("Start Goblin Hunt (auto-assign all combatants)", systemImage: "scope")
+            }
+            .buttonStyle(.borderedProminent)
+
+            if (user.activeHunts ?? []).isEmpty {
+                Text("No active hunts. Start one to earn passive gold and complete combat bounties.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(user.activeHunts ?? []) { hunt in
+                    HuntRowView(hunt: hunt, user: user, modelContext: modelContext)
+                }
+            }
+        }
+        .padding()
+        .background(Material.regular)
+        .cornerRadius(10)
+    }
+}
+
+struct HuntRowView: View {
+    @Bindable var hunt: ActiveHunt
+    @Bindable var user: User
+    var modelContext: ModelContext
+
+    private func dpsText() -> String {
+        let dps = GuildManager.shared.totalPartyDPS(memberIDs: hunt.memberIDs, on: user)
+        return String(format: "%.1f DPS", dps)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(hunt.enemy?.name ?? "Unknown Enemy").bold()
+                Spacer()
+                Text(dpsText()).font(.caption).foregroundColor(.secondary)
+            }
+            Text("Kills: \(hunt.killsAccumulated)").font(.caption)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(hunt.memberIDs, id: \.self) { id in
+                        if let member = user.guildMembers?.first(where: { $0.id == id }) {
+                            Text(member.name)
+                                .font(.caption2)
+                                .padding(6)
+                                .background(Color.blue.opacity(0.1))
+                                .cornerRadius(6)
+                        }
+                    }
+                }
+            }
+            HStack {
+                Button("Stop Hunt") {
+                    GuildManager.shared.stopHunt(hunt, for: user, context: modelContext)
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+        }
+        .padding()
+        .background(Material.thin)
         .cornerRadius(10)
     }
 }

--- a/IdleGameManager.swift
+++ b/IdleGameManager.swift
@@ -108,4 +108,9 @@ final class IdleGameManager: ObservableObject {
             }
         }
     }
+
+    // MARK: - Offline Hunts
+    func processOfflineHunts(for user: User, context: ModelContext) {
+        GuildManager.shared.processOfflineHunts(for: user, context: context)
+    }
 }

--- a/ProjectChimeraApp.swift
+++ b/ProjectChimeraApp.swift
@@ -44,8 +44,9 @@ struct ProjectChimeraApp: App {
                     PlantedTree.self,
                     GuildMember.self,
                     ActiveExpedition.self,
-                    AltarOfWhispers.self,
-                    WeeklyChallenge.self
+                                        AltarOfWhispers.self,
+                     WeeklyChallenge.self,
+                     ActiveHunt.self
                 ])
         }
     }

--- a/SanctuaryView.swift
+++ b/SanctuaryView.swift
@@ -63,6 +63,7 @@ struct SanctuaryView: View {
                         QuestManager.shared.initializeQuests(for: user, context: modelContext)
                         GuildManager.shared.initializeGuild(for: user, context: modelContext)
                         GuildManager.shared.generateDailyBounties(for: user, context: modelContext)
+                        IdleGameManager.shared.processOfflineHunts(for: user, context: modelContext)
                     }
                 } else {
                     ContentUnavailableView("Loading...", systemImage: "hourglass")


### PR DESCRIPTION
Adds mercenary hiring and passive combat hunts for continuous mob killing and reward generation.

This feature introduces hireable combat mercenaries (Knights, Archers, Wizards, Rogues, Clerics) who can be assigned to 'hunts' to passively defeat enemies. These hunts generate gold and progress combat-specific Guild bounties, continuing even after bounty completion. Offline progress is also supported, allowing rewards to accrue while the player is away, mirroring the passive gain mechanics of the Altar of Whispers.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a24ad67-4ecf-41b2-abc9-ad87ce2ffde9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a24ad67-4ecf-41b2-abc9-ad87ce2ffde9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

