### PR TITLE
Troubleshoot and fix Xcode build errors

### DIFF
--- a/HealthKitManager.swift
+++ b/HealthKitManager.swift
@@ -1,3 +1,4 @@
+#if canImport(HealthKit)
 import Foundation
 import HealthKit
 
@@ -189,3 +190,14 @@ class HealthKitManager: ObservableObject {
         healthStore.execute(query)
     }
 }
+#else
+import Foundation
+
+class HealthKitManager: ObservableObject {
+    func requestAuthorization(completion: @escaping (Bool) -> Void) { completion(false) }
+    func fetchSleepData(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchStepCount(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchWorkoutDuration(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchMindfulMinutes(completion: @escaping (Double?) -> Void) { completion(nil) }
+}
+#endif

--- a/ProjectChimeraApp.swift
+++ b/ProjectChimeraApp.swift
@@ -1,3 +1,4 @@
+#if !SWIFT_PACKAGE
 import SwiftUI
 import SwiftData
 
@@ -44,10 +45,11 @@ struct ProjectChimeraApp: App {
                     PlantedTree.self,
                     GuildMember.self,
                     ActiveExpedition.self,
-                                        AltarOfWhispers.self,
-                     WeeklyChallenge.self,
-                     ActiveHunt.self
+                    AltarOfWhispers.self,
+                    WeeklyChallenge.self,
+                    ActiveHunt.self
                 ])
         }
     }
 }
+#endif

--- a/problem-child/HealthKitManager.swift
+++ b/problem-child/HealthKitManager.swift
@@ -1,3 +1,4 @@
+#if canImport(HealthKit)
 import Foundation
 import HealthKit
 
@@ -189,3 +190,14 @@ class HealthKitManager: ObservableObject {
         healthStore.execute(query)
     }
 }
+#else
+import Foundation
+
+class HealthKitManager: ObservableObject {
+    func requestAuthorization(completion: @escaping (Bool) -> Void) { completion(false) }
+    func fetchSleepData(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchStepCount(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchWorkoutDuration(completion: @escaping (Double?) -> Void) { completion(nil) }
+    func fetchMindfulMinutes(completion: @escaping (Double?) -> Void) { completion(nil) }
+}
+#endif

--- a/problem-child/Package.swift
+++ b/problem-child/Package.swift
@@ -2,20 +2,20 @@
 import PackageDescription
 
 let package = Package(
-    name: "ProjectChimera",
+    name: "ProjectChimeraProblemChild",
     platforms: [
         .iOS(.v17),
         .macOS(.v14)
     ],
     products: [
         .library(
-            name: "ProjectChimera",
-            targets: ["ProjectChimera"]),
+            name: "ProjectChimeraProblemChild",
+            targets: ["ProjectChimeraProblemChild"]),
     ],
     dependencies: [],
     targets: [
         .target(
-            name: "ProjectChimera",
+            name: "ProjectChimeraProblemChild",
             dependencies: [],
             path: ".",
             sources: [

--- a/problem-child/ProjectChimeraApp.swift
+++ b/problem-child/ProjectChimeraApp.swift
@@ -1,3 +1,4 @@
+#if !SWIFT_PACKAGE
 import SwiftUI
 import SwiftData
 
@@ -44,10 +45,11 @@ struct ProjectChimeraApp: App {
                     PlantedTree.self,
                     GuildMember.self,
                     ActiveExpedition.self,
-                                        AltarOfWhispers.self,
-                     WeeklyChallenge.self,
-                     ActiveHunt.self
+                    AltarOfWhispers.self,
+                    WeeklyChallenge.self,
+                    ActiveHunt.self
                 ])
         }
     }
 }
+#endif


### PR DESCRIPTION
Enable Xcode build by guarding app entry, stubbing HealthKit, and renaming nested package.

These changes resolve common Xcode build errors:
1.  Wrapping `ProjectChimeraApp` with `#if !SWIFT_PACKAGE` prevents "multiple @main" errors when the package is consumed as a library.
2.  Adding `#if canImport(HealthKit)` and a no-op fallback for `HealthKitManager` allows the code to compile on platforms/targets where HealthKit is unavailable.
3.  Renaming the nested package to `ProjectChimeraProblemChild` avoids module/product name collisions when both the root and nested packages are included in the same Xcode workspace.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c7202a3-f353-4234-8797-099528485ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c7202a3-f353-4234-8797-099528485ac9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

