### PR TITLE
Fix initial user creation to prevent perpetual loading

### DIFF
--- a/MainView.swift
+++ b/MainView.swift
@@ -130,8 +130,13 @@ struct AppTabView: View {
         // Initialize other managers
         ChallengeManager.shared.generateWeeklyChallenges(for: newUser, context: modelContext)
         SpellbookManager.shared.unlockNewSpells(for: newUser)
-        
-        print("Default user created successfully")
+
+        do {
+            try modelContext.save()
+            print("Default user created successfully")
+        } catch {
+            print("Failed to save default user: \(error)")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Persist the default user to the SwiftData model context during startup
- Log failures if saving the default user fails

## Testing
- `swift build` *(fails: no such module 'SwiftData')*

------
https://chatgpt.com/codex/tasks/task_e_68956daf11a4832f95c7adad6d181d23